### PR TITLE
More performance improvements.

### DIFF
--- a/lib/memonic.rb
+++ b/lib/memonic.rb
@@ -20,7 +20,7 @@ module Memonic
   module ClassMethods
     def memoize(name, &block)
       define_method(name) do
-        singleton_class.class_eval { attr_reader name }
+        singleton_class.send(:attr_reader, name.to_sym)
         instance_variable_set("@#{name}", instance_exec(&block))
       end
     end

--- a/lib/memonic.rb
+++ b/lib/memonic.rb
@@ -19,18 +19,10 @@ module Memonic
 
   module ClassMethods
     def memoize(name, &block)
-      define_method("__#{name}__", &block)
-      class_eval <<-RUBY
-        def #{name}
-          @#{name} || begin
-            if defined?(@#{name})
-              @#{name}
-            else
-              @#{name} = __#{name}__
-            end
-          end
-        end
-      RUBY
+      define_method(name) do
+        singleton_class.class_eval { attr_reader name }
+        instance_variable_set("@#{name}", instance_exec(&block))
+      end
     end
   end
 end


### PR DESCRIPTION
Builds on the [previous performance-related pull request](#1) with a more radical variation on the class version of `memoize`. This time it defines a method that replaces itself with an `attr_reader` before setting the instance variable using the supplied block. This makes the first call to the memorised method very expensive, but subsequent calls become very cheap.

In testing, this yielded an impressive performance improvement when a memoized method was called a very large number of times in a given instance's lifetime. However, the break-even point was about 200 calls, so it's not really practical, but I thought I'd put it up for interest's sake.
